### PR TITLE
fix(oauth2) : use last refreshed access token

### DIFF
--- a/src/spotify.js
+++ b/src/spotify.js
@@ -21,6 +21,7 @@ module.exports = function (RED) {
                     handleInput(msg);
                 });
             } else {
+                spotifyApi.setAccessToken(node.config.credentials.accessToken);
                 handleInput(msg);
             }
         });


### PR DESCRIPTION
in case of multiple spotify nodes, only the first node who hit expireTime have the refreshed access token all the other node continue to use the previous one and hit auth error

with my fix all nodes retrieve last access token before handleInput

